### PR TITLE
refactor: move DB credentials to env variables in docker-compose

### DIFF
--- a/Backend/crm-backend/.gitignore
+++ b/Backend/crm-backend/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Variables de entorno ##
+.env

--- a/Backend/crm-backend/docker-compose.yml
+++ b/Backend/crm-backend/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - DB_URL=jdbc:postgresql://aws-1-us-east-1.pooler.supabase.com:6543/postgres?prepareThreshold=0
-      - DB_USERNAME=postgres.cyohgfityjrccegxuftb
-      - DB_PASSWORD=CRM-Inteligente
-      - PORT=8080
+      - DB_URL=${DB_URL}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - PORT=${PORT:-8080}
     restart: always


### PR DESCRIPTION
🔐 Seguridad - Variables de entorno
Se removieron credenciales hardcodeadas del docker-compose.yml y se migraron a variables de entorno mediante .env.
✅ Cambios
•	Uso de ${DB_URL}, ${DB_USERNAME}, ${DB_PASSWORD}
•	Se agregó PORT como variable configurable
•	Se agregó .env al .gitignore
🧪 Validación
•	La aplicación levanta correctamente con variables de entorno
•	Conexión a la base de datos funcional
⚠️ Pendiente (infraestructura)
Debido a que las credenciales estuvieron expuestas en el repositorio:
- [ ] Rotar contraseña en Supabase  
- [ ] Actualizar variables en Render
